### PR TITLE
Feature/ncs 2.2.0

### DIFF
--- a/app/conf/common.conf
+++ b/app/conf/common.conf
@@ -2,6 +2,5 @@
 # and is always used.
 
 CONFIG_GPIO=y
-CONFIG_LOG=y
 
 CONFIG_VERSION_INFO=y

--- a/app/conf/debug.conf
+++ b/app/conf/debug.conf
@@ -1,7 +1,6 @@
 # This is a Kconfig fragment which can be used to enable debug-related options
 # in the application.
 
-# Compiler
 # Compiler optimizations will be set to -Og independently of other options.
 CONFIG_DEBUG_OPTIMIZATIONS=y
 # This option adds additional information to the thread object, so that the
@@ -12,5 +11,11 @@ CONFIG_DEBUG_THREAD_INFO=y
 # information to be reported at runtime.
 CONFIG_DEBUG_INFO=y
 
-# Logging
-CONFIG_LOG=y
+# asserts
+CONFIG_ASSERT=y
+# if enabling asserts takes up to much code space, consider enabling these options
+# CONFIG_ASSERT_NO_COND_INFO=y
+# CONFIG_ASSERT_NO_MSG_INFO=y
+# This one shuld be anabled as a last resort, since the file nad location of the assert will not be printed,
+# thus lowering the usefullness of the assert significantly
+# CONFIG_CONFIG_ASSERT_NO_FILE_INFO=y

--- a/app/conf/rtt.conf
+++ b/app/conf/rtt.conf
@@ -1,12 +1,11 @@
 # This is a Kconfig fragment which can be used to enable Segger RTT options.
 # It should be used in conjunction with debug.conf.
 
+# Logging
+CONFIG_LOG=y
+
 # Console
 CONFIG_CONSOLE=y
-
-# This is needed, printk is forced to use logging backend which is by default
-# deffered
-CONFIG_LOG_MODE_IMMEDIATE=y
 
 # segger RTT console
 CONFIG_USE_SEGGER_RTT=y

--- a/app/conf/uart.conf
+++ b/app/conf/uart.conf
@@ -1,6 +1,9 @@
 # This is a Kconfig fragment which can be used to enable UART console options.
 # It should be used in conjunction with debug.conf.
 
+# Logging
+CONFIG_LOG=y
+
 # Console
 CONFIG_CONSOLE=y
 

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
-#include <logging/log.h>
-#include <sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/printk.h>
+
 #include <version_info.h>
-#include <zephyr.h>
 
 /* 1000 msec = 1 sec */
 #define SLEEP_TIME_MS 1000

--- a/east.yml
+++ b/east.yml
@@ -1,0 +1,27 @@
+apps:
+  - name: app
+    west-boards:
+      - custom_nrf52840dk
+      - nrf52840dk_nrf52840
+
+    build-types:
+      - type: debug
+        conf-files:
+          - debug.conf
+      - type: uart
+        conf-files:
+          - debug.conf
+          - uart.conf
+      - type: rtt
+        conf-files:
+          - debug.conf
+          - rtt.conf
+
+# There are no samples, but one sample entry must exist in east 0.4.0
+samples:
+  - name: sample_name
+    west-boards:
+      - custom_nrf52840dk
+    inherit-build-type:
+      app: app
+      build-type: uart

--- a/west.yml
+++ b/west.yml
@@ -16,7 +16,7 @@ manifest:
       remote: nrfconnect
       # IMPORTANT: When changing NCS revision you need to change revision of
       # Zephyr project below so it matches.
-      revision: v2.1.0
+      revision: v2.2.0
       import:
         name-allowlist:
           # Ignore NCS private repos, keep this list sorted alphabetically.
@@ -43,7 +43,7 @@ manifest:
     - name: zephyr
       remote: nrfconnect
       repo-path: sdk-zephyr
-      revision: v3.1.99-ncs1
+      revision: v3.2.99-ncs1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -66,7 +66,7 @@ manifest:
           # - fatfs
           # - fff
           - hal_nordic
-          - hal_st  # Hal for ST's sensors, not for MCU's
+          - hal_st # Hal for ST's sensors, not for MCU's
           # - liblc3codec
           # - libmetal
           # - littlefs
@@ -91,4 +91,4 @@ manifest:
       repo-path: irnas-versioninfo-lib
       path: irnas/irnas-versioninfo-lib
       remote: irnas
-      revision: v1.1.0
+      revision: v1.1.1


### PR DESCRIPTION
Update` west.yml` to use NCS 2.2.
Fix headers in `main.c,` since all zephyr headers now require the `zephyr/` prefix.

Add `east.yml` that works with east `v0.4.0` and refactor conf files to the east-expected names/location.

I also updated `version-info-lib` to 1.1.1, where I also fixed the zephyr headers.