### PR TITLE
Enable mbedtls by default in west.yaml

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -33,8 +33,8 @@ manifest:
           # - homekit
           # - hostap
           # - matter
-          # - mbedtls
-          # - mbedtls-nrf
+          - mbedtls # Required for nRF9160 and nRF7002 projects, can be disabled for others.
+          - mbedtls-nrf # Required for nRF9160 and nRF7002 projects, can be disabled for others.
           - mcuboot
           # - memfault-firmware-sdk
           # - nrf-802154


### PR DESCRIPTION
## Description

I think it is better to have this enabled. Projects not using nrf916X can disable them.

Alternatively, we could add a comment to say that this should be enabled in nrf916X projects.

@MarkoSagadin thoughts?

## After-review steps

<!--- Delete section or select one option -->

- Reviewer can merge and delete the branch.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
