### PR TITLE
infra: replace beautysh with shfmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,10 +62,11 @@ repos:
     hooks:
       - id: shellcheck
         stages: [pre-commit]
-  - repo: https://github.com/lovesegfault/beautysh
-    rev: v6.2.1
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.8.0-1
     hooks:
-      - id: beautysh
+      - id: shfmt
+        stages: [pre-commit]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.4
     hooks:


### PR DESCRIPTION
# Description

beautysh is unmaintained and doesn't work with Python 3.12. The new hook delivers the shfmt tool as a pre-build binary (as it is written in Golang) so no extra dependencies are needed for this.

Closes: #26

## Areas of interest for the reviewer

@vid553 can you make the change in your repo and test if the pre-commit works?

You should just run the `pre-commit run --all-files` after the change.

## After-review steps

<!--- Delete section or select one option -->

- **Reviewer can merge and delete the branch**.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
