### PR TITLE
fix(tests): Specify native_sim in sample testcase

### DIFF
--- a/tests/sample_test/testcase.yaml
+++ b/tests/sample_test/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   tests.sample_test.posix:
     # Set of platforms that this test case can be run on.
-    platform_allow: native_posix
+    platform_allow: native_sim
     harness: ztest
     # Only build the test, do not run it
     # build_only: True


### PR DESCRIPTION
Since `make test` specifies native_sim as the target, no configurations are run when executing `make test` on the template repo as-is.

We change the sample test configuration to use native_sim instead of native_posix, so it is picked up when using `make test`.
