### PR TITLE
fix: Fix spelling in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ assignees: ""
 
 #### Steps to reproduce
 
-<!-- Steps to reproduce the behaviour: -->
+<!-- Steps to reproduce the behavior: -->
 
 <!-- 1. Go to '...' -->
 <!-- 2. Click on '....' -->

--- a/boards/vendor/custom_board/README.md
+++ b/boards/vendor/custom_board/README.md
@@ -1,8 +1,8 @@
 # Custom nRF52840 DK Board
 
-`custom_board` board is used to demonstrate how to create custom boards. It is in fact a
-simplified version of the nRF52840-DK board, so the `app` can be run on that development kit when
-using `custom_board`.
+`custom_board` board is used to demonstrate how to create custom boards. It is in fact a simplified
+version of the nRF52840-DK board, so the `app` can be run on that development kit when using
+`custom_board`.
 
 Only specialty is that the jlink runner is used by default when using `west flash`, this is set by
 `board.cmake` file.


### PR DESCRIPTION
# Description

The Typos hook in precommit want American English, so we fix it.

## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and
write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] I updated all customer-facing technical documentation.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
