### PR TITLE
fix(CI): Fix PR labeler sometimes failing

### DIFF
--- a/.github/workflows/label_pr.yaml
+++ b/.github/workflows/label_pr.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: TimonVS/pr-labeler-action@v5.0.0


### PR DESCRIPTION
Prevent PR labeler action from failing sometimes, by also giving it the `issues:write` permission.

See [PR labeler repo issue[(Prevent PR labeler action from failing sometimes, by also giving it the issues:write permission.
