### PR TITLE
fix: Update make codechecker to use twister build types

### DIFF
--- a/makefile
+++ b/makefile
@@ -101,18 +101,18 @@ coverage-report: coverage-report-ci
 # directories with -d flag, so they can be analyzed separately, see examples
 # below.
 codechecker-build:
-	east build -b custom_board app -d build_app
-	east build -b custom_board app -u debug -d build_debug
+	east build -b custom_board app -T app.prod -d build_prod
+	east build -b custom_board app -T app.debug -d build_debug
 
 codechecker-check:
-	east codechecker check -d build_app
+	east codechecker check -d build_prod
 	east codechecker check -d build_debug
 
 codechecker-store:
-	east codechecker store -d build_app
+	east codechecker store -d build_prod
 	east codechecker store -d build_debug
 
 # Specify build folders that you want to analyze to the script as positional
 # arguments, open it to learn more.
 codechecker-diff:
-	scripts/codechecker-diff.sh build_app build_debug
+	scripts/codechecker-diff.sh build_prod build_debug


### PR DESCRIPTION
# Description

Fix codechecker in the makefile to use the new build targets and remove the old ones.

## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and
write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] ~~I updated all customer-facing technical documentation.~~ - This PR
      introduced only internal facing changes.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
